### PR TITLE
CSE-790

### DIFF
--- a/AWSSNS.agent.lib.nut
+++ b/AWSSNS.agent.lib.nut
@@ -68,9 +68,9 @@ class AWSSNS {
      *
      * @constructor
      *
-     * @param {USB.Device} region          - AWS region.
-     * @param {USB.Device} accessKeyId     - AWS access key ID.
-     * @param {USB.Device} secretAccessKey - AWS secret access key.
+     * @param {USB.Device} region          - An AWS region.
+     * @param {USB.Device} accessKeyId     - An AWS access key ID.
+     * @param {USB.Device} secretAccessKey - An AWS secret access key.
      *
      * @returns {instance} The instance.
      */

--- a/AWSSNS.agent.lib.nut
+++ b/AWSSNS.agent.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -22,37 +22,73 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-const AWSSNS_ACTION_CONFIRM_SUBSCRIPTION        = "ConfirmSubscription";
-const AWSSNS_ACTION_LIST_SUBSCRIPTIONS          = "ListSubscriptions";
-const AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC = "ListSubscriptionsByTopic";
-const AWSSNS_ACTION_LIST_TOPICS                 = "ListTopics";
-const AWSSNS_ACTION_PUBLISH                     = "Publish";
-const AWSSNS_ACTION_SUBSCRIBE                   = "Subscribe";
-const AWSSNS_ACTION_UNSUBSCRIBE                 = "Unsubscribe";
 
+/**
+ * Enum for SNS actions.
+ * @enum {string}
+ * @readonly
+*/
+enum AWSSNS_ACTIONS {
+    CONFIRM_SUBSCRIPTION        = "ConfirmSubscription",
+    LIST_SUBSCRIPTIONS          = "ListSubscriptions",
+    LIST_SUBSCRIPTIONS_BY_TOPIC = "ListSubscriptionsByTopic",
+    LIST_TOPICS                 = "ListTopics",
+    PUBLISH                     = "Publish",
+    SUBSCRIBE                   = "Subscribe",
+    UNSUBSCRIBE                 = "Unsubscribe"
+}
+
+/**
+ * Enum for SNS action response indentifiers.
+ * @enum {string}
+ * @readonly
+*/
+enum AWSSNS_RESPONSES {
+    SUBSCRIPTION_CONFIRMATION = "SubscriptionConfirmation",
+}
+
+/**
+ * Squirrel class providing support for AWS' SNS service.
+ *
+ * Availibility Agent
+ * Requires     AWSRequestV4
+ * @author      Pavel Petrosenko
+ * @license     MIT
+ *
+ * @class
+*/
 class AWSSNS {
 
-    static VERSION = "1.0.0";
+    static VERSION = "2.0.0";
 
     _awsRequest = null;
 
-    // Parameters:
-    //     region            AWS region
-    //     accessKeyId       AWS access key Id
-    //     secretAccessKey   AWS secret access key
+    /**
+     * Instantiate the AWSSNS class.
+     *
+     * @constructor
+     *
+     * @param {USB.Device} region          - AWS region.
+     * @param {USB.Device} accessKeyId     - AWS access key ID.
+     * @param {USB.Device} secretAccessKey - AWS secret access key.
+     *
+     * @returns {instance} The instance.
+     */
     constructor(region, accessKeyId, secretAccessKey) {
         if ("AWSRequestV4" in getroottable()) {
             _awsRequest = AWSRequestV4("sns", region, accessKeyId, secretAccessKey);
         } else {
-            throw("This class requires AWSRequestV4 - please make sure it is loaded.");
+            throw "This class requires AWSRequestV4 - please make sure it is loaded.";
         }
     }
 
-    // Performs the specified action
-    //
-    // Parameters:
-    //      params              table of parameters to be sent as part of the request
-    //      cb                  callback function to be called when response received from aws
+    /**
+     * Performs the specified action.
+     *
+     * @param {string}   action - The name of the action to be performed.
+     * @param {table}    params - Parameters to be sent as part of the request.
+     * @param {function} cb     - Callback function triggered when response received from AWS.
+    */
     function action(action, params, cb) {
         local headers = {"Content-Type": "application/x-www-form-urlencoded"};
         local body = {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2017 Electric Imp
+Copyright 2017-19 Electric Imp
 
 SPDX-License-Identifier: MIT
 

--- a/README.md
+++ b/README.md
@@ -1,81 +1,90 @@
-# AWSSNS &mdash; Amazon Simple Notification Service Library
+# AWSSNS 2.0.0 #
 
 This library implements [Amazon Simple Notification Service (SNS)](https://aws.amazon.com/documentation/sns/) actions in agent code.
 
-**To add this library to your application, add the following lines to the top of your agent code:**
+**To include this library in your project, add the following lines at the top of your agent code:**
 
-```
+```squirrel
 #require "AWSRequestV4.class.nut:1.0.2"
-#require "AWSSNS.agent.lib.nut:1.0.0"
+#require "AWSSNS.agent.lib.nut:2.0.0"
 ```
 
-**Note** [AWSRequestV4](https://github.com/electricimp/AWSRequestV4/) must be included **before** the AWSSNS library.
+**Important** The [AWSRequestV4](https://github.com/electricimp/AWSRequestV4/) library must be included **before** the AWSSNS library.
 
 ![Build Status](https://cse-ci.electricimp.com/app/rest/builds/buildType:(id:Awssns_BuildAndTest)/statusIcon)
 
-## Class Usage
+## Class Usage ##
 
-### constructor(*region, accessKeyID, secretAccessKey*)
+### constructor(*region, accessKeyID, secretAccessKey*) ###
 
-The constructor takes the following parameters, all of which are required:
+#### Parameters ####
 
-Parameter              | Type           | Description
----------------------- | -------------- | -----------
-*region*                 | string         | AWS region (eg. `"us-west-2"`)
-*accessKeyId*            | string         | IAM Access Key ID
-*secretAccessKey*        | string         | IAM Secret Access Key
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *region*  | String | Yes | An AWS region (eg. `us-west-2`) |
+| *accessKeyId* | String | Yes | Your IAM Access Key ID |
+| *secretAccessKey* | String | Yes | Your IAM Secret Access Key |
 
-#### Example
+#### Example ####
 
 ```squirrel
+#require "AWSRequestV4.class.nut:1.0.2"
+#require "AWSSNS.agent.lib.nut:2.0.0"
+
 const AWS_SNS_ACCESS_KEY_ID     = "<YOUR_ACCESS_KEY_ID>";
 const AWS_SNS_SECRET_ACCESS_KEY = "<YOUR_SECRET_ACCESS_KEY_ID>";
 const AWS_SNS_URL               = "<YOUR_SNS_URL>";
 const AWS_SNS_REGION            = "<YOUR_REGION>";
 
 // Instantiate the class
-sns <- AWSSNS(AWS_SNS_REGION, AWS_SNS_ACCESS_KEY_ID, AWS_SNS_SECRET_ACCESS_KEY);
+sns <- AWSSNS(AWS_SNS_REGION,
+              AWS_SNS_ACCESS_KEY_ID,
+              AWS_SNS_SECRET_ACCESS_KEY);
 ```
 
-## Class Methods
+## Class Methods ##
 
-### action(*actionType, params, callback*)
+### action(*actionType, params, callback*) ###
 
-This method performs a specified action (eg. publish) with the required parameters (*params*) for the specified action type.
+This method performs a specified action (eg. publish) with the required parameters for the specified action’s type.
 
-Parameter         |       Type     | Description
------------------ | -------------- | -----------
-*actionType*       | Constant         | The type of the Amazon SNS action that you want to perform (see ‘Action Types’, below)
-*params*            | Table          | Table of action-specific parameters (see ‘Action Parameters’, below)
-*callback*            | Function       | Callback function that takes one parameter: a [Callback Response Table](#callback-response-table)
+#### Parameters ####
 
-#### Action Types
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *actionType* | String | Yes | The type of the Amazon SNS action that you want to perform. See [**Action Types**](#action-types), below |
+| *params* | Table | Yes | Action-specific parameters. These are listed for each action under [**Action Types**](#action-types), below. Pass an empty table, `{}`, if you have no parameters to update |
+| *callback* | Function | Yes | A callback function that receives one argument, a [Callback Response Table](#callback-response-table) |
 
-Action Type                                                                             | Description
---------------------------------------------------------------------------------------- | --------------------------------------
-[*AWSSNS_ACTION_CONFIRM_SUBSCRIPTION*](#awssns_action_confirm_subscription)               | Verifies an endpoint owner’s intent to receive messages
-[*AWSSNS_ACTION_LIST_SUBSCRIPTIONS*](#awssns_action_list_subscriptions)                   | Returns an XML list of the requester’s subscriptions
-[*AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC*](#awssns_action_list_subscriptions_by_topic) | Returns an XML list of the subscriptions to a specific topic
-[*AWSSNS_ACTION_LIST_TOPICS*](#awssns_action_list_topics)                                 | Returns an XML list of the requester’s topics
-[*AWSSNS_ACTION_PUBLISH*](#awssns_action_publish)                                         | Sends a message to an Amazon SNS topic
-[*AWSSNS_ACTION_SUBSCRIBE*](#awssns_action_subscribe)                                     | Prepares to subscribe to an endpoint
-[*AWSSNS_ACTION_UNSUBSCRIBE*](#awssns_action_unsubscribe)                                 | Deletes a subscription
+### Action Types ###
 
-#### Action Parameters
+The following action types are provided by the library through its own constants.
 
-Specific actions of the types listed above are configured by passing information into *action()*’s *params* parameter as a table with the following action type-specific keys.
+| Action Type Constant | Description |
+| --- | --- |
+| [*AWSSNS_ACTION_CONFIRM_SUBSCRIPTION*](#awssns_action_confirm_subscription) | Verifies an endpoint owner’s intent to receive messages |
+| [*AWSSNS_ACTION_LIST_SUBSCRIPTIONS*](#awssns_action_list_subscriptions) | Returns an XML list of the requester’s subscriptions |
+| [*AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC*](#awssns_action_list_subscriptions_by_topic) | Returns an XML list of the subscriptions to a specific topic |
+| [*AWSSNS_ACTION_LIST_TOPICS*](#awssns_action_list_topics) | Returns an XML list of the requester’s topics |
+| [*AWSSNS_ACTION_PUBLISH*](#awssns_action_publish) | Sends a message to an Amazon SNS topic |
+| [*AWSSNS_ACTION_SUBSCRIBE*](#awssns_action_subscribe) | Prepares to subscribe to an endpoint |
+| [*AWSSNS_ACTION_UNSUBSCRIBE*](#awssns_action_unsubscribe) | Deletes a subscription |
 
-#### AWSSNS_ACTION_CONFIRM_SUBSCRIPTION
+#### AWSSNS_ACTION_CONFIRM_SUBSCRIPTION ####
 
 Verifies an endpoint owner’s intent to receive messages by validating the token sent to the endpoint by an earlier Subscribe action. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_ConfirmSubscription.html) for more information.
 
-Parameter                 | Type    | Required | Default | Description
-------------------------- | ------- | -------- | ------- | -------------------
-*AuthenticateOnUnsubscribe* | String  | No       | `null`    | Disallows unauthenticated unsubscribes of the subscription. If the value of this parameter is `true` and the request has an AWS signature, then only the topic owner and the subscription owner can unsubscribe the endpoint. The unsubscribe action requires AWS authentication
-*Token*                     | String  | Yes      | N/A     | Short-lived token sent to an endpoint during the Subscribe action
-*TopicArn*                  | String  | Yes      | N/A     | The ARN of the topic for which you wish to confirm a subscription
+#### Action Parameters ####
 
-<h5 id="ida">Example</h5>
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *AuthenticateOnUnsubscribe* | String | No | Disallows unauthenticated unsubscribes of the subscription. If the value of this parameter is `true` and the request has an AWS signature, then only the topic owner and the subscription owner can unsubscribe the endpoint. The unsubscribe action requires AWS authentication. Default: `null` |
+| *Token* | String  | Yes | Short-lived token sent to an endpoint during the Subscribe action |
+| *TopicArn* | String  | Yes | The ARN of the topic for which you wish to confirm a subscription |
+
+<a id="ida"></a>
+
+#### Example ####
 
 ```squirrel
 http.onrequest(function (request, response) {
@@ -83,16 +92,16 @@ http.onrequest(function (request, response) {
         local requestBody = http.jsondecode(request.body);
 
         // Handle an SES SubscriptionConfirmation request
-        if ("Type" in requestBody && requestBody.Type == "SubscriptionConfirmation") {
-            server.log("Received HTTP Request: AWS_SNS SubscriptionConfirmation");
+        if ("Type" in requestBody && requestBody.Type == AWSSNS_RESPONSES.SUBSCRIPTION_CONFIRMATION) {
+            server.log("Received HTTP Request: AWS SNS SubscriptionConfirmation");
 
             local confirmParams = {
                 "Token": requestBody.Token,
                 "TopicArn": requestBody.TopicArn
             };
 
-            sns.action(AWSSNS_ACTION_CONFIRM_SUBSCRIPTION, confirmParams, function (res) {
-                server.log("Confirmation Response: " +res.statuscode);
+            sns.action(AWSSNS_ACTIONS.CONFIRM_SUBSCRIPTION, confirmParams, function (response) {
+                server.log("Confirmation Response: " + response.statuscode);
             });
         }
 
@@ -105,30 +114,34 @@ http.onrequest(function (request, response) {
 });
 ```
 
-#### AWSSNS_ACTION_LIST_SUBSCRIPTIONS
+#### AWSSNS_ACTION_LIST_SUBSCRIPTIONS ####
 
 Returns an XML list of the requester’s subscriptions as a string in the response table. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_ListSubscriptions.html) for more information.
 
-Parameter                 | Type    | Required | Default | Description
-------------------------- | ------- | -------- | ------- | -------------------
-*NextToken*                 | String  | No       | `null`    | Token returned by the previous ListSubscriptions request
+#### Action Parameters ####
 
-##### Example #####
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *NextToken* | String  | No | Token returned by the previous ListSubscriptions request. Default: `null` |
+
+#### Example ####
 
 ```squirrel
-sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS, {}, function (response) {
+sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS, {}, function (response) {
     // Do something with the returned XML
 });
 ```
 
-#### AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC
+#### AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC ####
 
 Returns an XML list of the subscriptions to a specific topic as a string in the response table. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_ListSubscriptionsByTopic.html) for more information.
 
-Parameter                 | Type    | Required | Default | Description
-------------------------- | ------- | -------- | ------- |  ------------------
-*NextToken*                 | String  | No       | `null` | Token returned by the previous ListSubscriptionsByTopic request
-*TopicArn*                  | String  | Yes      | N/A     | The ARN of the topic for which you wish to confirm a subscription
+#### Action Parameters ####
+
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *NextToken* | String  | No | Token returned by the previous ListSubscriptionsByTopic request. Default: `null` |
+| *TopicArn* | String  | Yes | The ARN of the topic for which you wish to confirm a subscription |
 
 ##### Example #####
 
@@ -137,14 +150,14 @@ Parameter                 | Type    | Required | Default | Description
 local endpointFinder = function (messageBody) {
     local endpoint = http.agenturl();
     local start = messageBody.find(endpoint);
-    start = start + endpoint.len();
+    start += endpoint.len();
     return start;
 };
 
 // Finds the SubscriptionArn corresponding to the specified endpoint
 local subscriptionFinder = function (messageBody, startIndex) {
-    local start = messageBody.find(AWS_SNS_SUBSCRIPTION_ARN_START, startIndex);
-    local finish = messageBody.find(AWS_SNS_SUBSCRIPTION_ARN_FINISH, startIndex);
+    local start = messageBody.find("<SubscriptionArn>", startIndex);
+    local finish = messageBody.find("</SubscriptionArn>", startIndex);
     local subscription = messageBody.slice((start + 17), (finish));
     return subscription;
 };
@@ -153,53 +166,57 @@ local params = {
     "TopicArn": "YOUR_TOPIC_ARN_HERE"
 };
 
-sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC, params, function (response) {
+sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS_BY_TOPIC, params, function (response) {
     // Finds your specific subscription ARN
     local subscriptionArn = subscriptionFinder(response.body, endpointFinder(response.body));
 });
 ```
 
-#### AWSSNS_ACTION_LIST_TOPICS
+#### AWSSNS_ACTION_LIST_TOPICS ####
 
 Returns an XML list of the requester’s topics as a string in the response table. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_ListTopics.html) for more information.
 
-Parameter                 | Type    | Required | Default | Description
-------------------------- | ------- | -------- | ------- | --------------------
-*NextToken*                 | String  | No       | `null`  | Token returned by the previous ListTopics request
+#### Action Parameters ####
+
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *NextToken* | String | No | Token returned by the previous ListTopics request. Default: `null` |
 
 ##### Example #####
 
 ```squirrel
-sns.action(AWSSNS_ACTION_LIST_TOPICS, {}, function (response) {
+sns.action(AWSSNS_ACTIONS.LIST_TOPICS, {}, function (response) {
     // Do something the returned XML
 })
 ```
 
-#### AWSSNS_ACTION_PUBLISH
+#### AWSSNS_ACTION_PUBLISH ####
 
-Sends a message to an Amazon SNS topic or sends a text message (SMS message) directly to a phone number. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_Publish.html) for more information.
-
-Parameter                | Type    | Required | Default | Description
------------------------- | ------- | -------- | ------- | -------------------
-*Message*                  | String  | Yes      | N/A     | The message you want to send
-*MessageAttributes*        | Table   | No       | `null`    | *MessageAttributes.entry.N.Name* (key), *MessageAttributes.entry.N.Value* (value) pairs. see the ‘MessageAttributes Values’ table, below, for more information
-*MessageStructure*         | String  | No       | `null`    | Set message structure to JSON if you want to send a different message for each protocol
-*PhoneNumber*              | String  | No       | `null`    | The phone number to which you want to deliver an SMS message
-*Subject*                  | String  | No       | `null`    | Optional parameter to be used as the ‘Subject’ line when the message is delivered to email endpoints
-*TargetArn*                | String  | No       | `null`    | Either TopicArn or EndpointArn, but not both
-*TopicArn*                | String  | No       | `null`    | The topic you want to publish to
+Sends a message to an Amazon SNS topic or sends a text message (SMS) directly to a phone number. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_Publish.html) for more information.
 
 **Note** You need at least one of the *TopicArn*, *PhoneNumber* or *TargetArn* parameters.
 
+#### Action Parameters ####
+
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *Message* | String  | Yes | The message you want to send |
+| *MessageAttributes* | Table | No | A table of *MessageAttributes.entry.N.Name* key amd *MessageAttributes.entry.N.Value* value pairs. For more information, see [**MessageAttributes Values**](#messageattributes-values), below. Default: `null` |
+| *MessageStructure* | String | No | Set message structure to JSON if you want to send a different message for each protocol. Default: `null` |
+| *PhoneNumber* | String | No | The phone number to which you want to deliver an SMS message. Default: `null` |
+| *Subject* | String | No | Optional parameter to be used as the ‘Subject’ line when the message is delivered to email endpoints. Default: `null` |
+| *TargetArn* | String | No | Either TopicArn or EndpointArn, but not both. Default: `null` |
+| *TopicArn* | String | No | The topic you want to publish to. Default: `null` |
+
 #### MessageAttributes Values ####
 
-Key                | Type                              | Required | Default | Description
------------------------- | --------------------------------  | -------- | ------- | -------------------
-*BinaryValue*              | Base64-encoded binary data object | No       | `null`    | Binary type attributes can store any binary data, for example, compressed data, encrypted data or images
-*DataType*                 | String                            | Yes      | N/A     | Amazon SNS supports the following logical data types: String, Number and Binary
-*StringValue*              | String                            | No       | null    | Strings are Unicode with UTF8 binary encoding
+| Key | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *BinaryValue* | Base64-encoded binary data object | No | Binary type attributes can store any binary, eg. compressed data, encrypted data or images. Default: `null` |
+| *DataType* | String | Yes | Amazon SNS supports the following logical data types: `String`, `Number` and `Binary` |
+| *StringValue* | String | No | Strings are Unicode with UTF8 binary encoding.  Default: `null` |
 
-##### Example #####
+#### Example ####
 
 ```squirrel
 local params = {
@@ -207,22 +224,24 @@ local params = {
     "TopicArn": AWS_SNS_TOPIC_ARN
 };
 
-sns.action(AWSSNS_ACTION_PUBLISH, params, function (response) {
+sns.action(AWSSNS_ACTIONS.PUBLISH, params, function (response) {
     // Check the status code (response.statuscode) for a successful publish
 });
 ```
 
-#### AWSSNS_ACTION_SUBSCRIBE
+#### AWSSNS_ACTION_SUBSCRIBE ####
 
 Prepares to subscribe to an endpoint by sending the endpoint a confirmation message. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html) for more information.
 
-Parameter                | Type    | Required | Default | Description
------------------------- | ------- | -------- | ------- | -------------------
-*Endpoint*                 | String  | No       | `null` | The endpoint that you want to receive notifications. Endpoints vary by protocol
-*Protocol*                 | String  | Yes      | N/A     | The protocol you want to use. Supported protocols include: HTTP, HTTPS, email, email-JSON, SMS, SQS, application and lambda
-*TopicArn*                 | String  | Yes      | N/A     | The topic you want to publish to
+#### Action Parameters ####
 
-##### Example #####
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *Endpoint* | String | No | The endpoint that you want to receive notifications. Endpoints vary by protocol |
+| *Protocol* | String | Yes | The protocol you want to use. Supported protocols include: `HTTP`, `HTTPS`, `email`, `email-JSON`, `SMS`, `SQS`, "application" and `lambda` |
+| *TopicArn* | String | Yes | The topic you want to publish to |
+
+#### Example ####
 
 ```squirrel
 subscribeParams <- {
@@ -231,19 +250,20 @@ subscribeParams <- {
     "Endpoint": http.agenturl()
 };
 
-sns.action(AWSSNS_ACTION_SUBSCRIBE, subscribeParams, function (response) {
+sns.action(AWSSNS_ACTIONS.SUBSCRIBE, subscribeParams, function (response) {
     server.log("Subscribe Response: " + http.jsonencode(response));
 });
 ```
 
-#### AWSSNS_ACTION_UNSUBSCRIBE
+#### AWSSNS_ACTION_UNSUBSCRIBE ####
 
 Deletes a subscription. Please view the [AWS SNS documentation](http://docs.aws.amazon.com/sns/latest/api/API_Unsubscribe.html) for more information.
 
-Parameter                | Type    | Required | Description
------------------------- | ------- | -------- | --------------------------
-*SubscriptionArn*          | String  | Yes      | The ARN of the subscription to be deleted
+#### Action Parameters ####
 
+| Parameter | Type | Required? | Description |
+| --- | --- | --- | --- |
+| *SubscriptionArn* | String | Yes | The ARN of the subscription to be deleted |
 
 ##### Example #####
 
@@ -251,10 +271,10 @@ See the ConfirmSubscription [example](#ida) to see how to get a value for *Subsc
 
 ```squirrel
 local params = {
-    "SubscriptionArn": YOUR_SUBSCRIPTION_ARN
+    "SubscriptionArn": "YOUR_SUBSCRIPTION_ARN_HERE"
 };
 
-sns.action(AWSSNS_ACTION_UNSUBSCRIBE, params, function(response) {
+sns.action(AWSSNS_ACTIONS.UNSUBSCRIBE, params, function(response) {
     server.log("Unsubscribe Response: " + http.jsonencode(response));
 });
 ```
@@ -263,23 +283,23 @@ sns.action(AWSSNS_ACTION_UNSUBSCRIBE, params, function(response) {
 
 The response table general to all functions contains the following keys:
 
-Key             |       Type     | Description
---------------------- | -------------- | -----------
-*body*                  | String         | AWS SNS response in an XML data structure which is received as a string
-*statuscode*            | Integer        | An HTTP status code
-*headers*               |Table          | See ‘Headers’, below
+| Key | Type | Description |
+| --- | --- | --- |
+| *body* | String | AWS SNS response in an XML data structure which is received as a string |
+| *statuscode* | Integer | An HTTP status code |
+| *headers* | Table | See [**Headers**](#headers), below |
 
-#### Headers
+#### Headers ####
 
 The *headers* key’s value is itself a table, with the following keys:
 
-Key             |       Type     | Description
---------------------- | -------------- | -----------
-*x-amzn-requestid*      | String         | The Amazon request ID
-*content-type*          | String         | The Content type eg. `text/XML`
-*date*                 | String         | The date and time at which the response was sent
-*content-length*        | String         | The length of the response content
+| Key | Type | Description |
+| --- | --- | --- |
+| *x-amzn-requestid* | String | The Amazon request ID |
+| *content-type* | String | The Content type eg. `text/XML` |
+| *date* | String | The date and time at which the response was sent |
+| *content-length* | String | The length of the response content |
 
-# License
+## License ##
 
-The AWSSNS library is licensed under the [MIT License](LICENSE).
+This library is licensed under the [MIT License](LICENSE).

--- a/example/README.md
+++ b/example/README.md
@@ -1,63 +1,59 @@
 # Demo Instructions
 
-This demo will show you how to subscribe, confirm a subscription and publish a message to a topic
+This demo will show you how to subscribe, confirm a subscription and publish a message to a topic.
 
 As the sample code includes the private key verbatim in the source, it should be treated carefully, and not checked into version control!
 
+## Set Up A Topic In AWS SNS ##
 
-## Setting up a Topic in AWS SNS
+1. Login to the [AWS console](https://aws.amazon.com/console/).
+1. Select **Services link** (on the top left of the page) and then type `SNS` in the search line.
+1. Select **Simple Notification Service**.
+1. Click **Create Topic**.
+1. Enter `testSNS` under **Topic name**.
+1. Enter `testSNS` under **DisplayName**.
+1. Click **Create Topic*.
+1. Note your Topic ARN and your Region.
 
-1. Login to the [AWS console](https://aws.amazon.com/console/)
-1. Select `Services link` (on the top left of the page) and then type `SNS` in the search line
-1. Select `Simple Notification Service`
-1. Click `Create Topic`
-1. Enter in `Topic name` "testSNS"
-1. Enter in `DisplayName` "testSNS"
-1. Click `Create Topic`
-1. Note your Topic ARN and your Region
+## Set Up An IAM Policy ##
 
-## Setting up IAM Policy
+1. Select the **Services** link (on the top left of the page) and them type `IAM` in the search line.
+1. Select the **IAM Manage User Access and Encryption Keys** item.
+1. Select the **Policies** item from the menu on the left.
+1. Click **Create Policy**.
+1. Click **Select** under **Policy Generator**.
+1. On the **Edit Permissions** page do the following:
+    1. Set **Effect** to **Allow**.
+    1. Set **AWS Service** to **Amazon SNS**.
+    1. Set **Actions** to **All Actions**.
+    1. Set **Amazon Resource Name (ARN)** to **&#42;**.
+    1. Click **Add Statement**.
+    1. Click **Next Step**.
+1. Give your policy a name, for example, `allow-sns` and type in into the **Policy Name** field.
+1. Click **Create Policy**.
 
-1. Select `Services` link (on the top left of the page) and them type `IAM` in the search line
-1. Select `IAM Manage User Access and Encryption Keys` item
-1. Select `Policies` item from the menu on the left
-1. Press `Create Policy` button
-1. Press `Select` for `Policy Generator`
-1. On the `Edit Permissions` page do the following
-    1. Set `Effect` to `Allow`
-    1. Set `AWS Service` to `Amazon SNS`
-    1. Set `Actions` to `All Actions`
-    1. Set `Amazon Resource Name (ARN)` to `*`
-    1. Press `Add Statement`
-    1. Press `Next Step`
-1. Give your policy a name, for example, `allow-sns` and type in into the `Policy Name` field
-1. Press `Create Policy`
+## Set Up An IAM User ##
 
-## Setting up the IAM User
+1. Select the **Services** link (on the top left of the page) and them type `IAM` in the search line.
+1. Select the **IAM Manage User Access and Encryption Keys** item.
+1. Select the **Users** item from the menu on the left.
+1. Click **Add user**.
+1. Choose a user name, for example `user-calling-sns`.
+1. Check **Programmatic access** but not anything else.
+1. Click **Next: Permissions**
+1. Click the **Attach existing policies directly** icon.
+1. Check **allow-sns** from the list of policies.
+1. Click **Next: Review**.
+1. Click **Create user**.
+1. Note your Access key ID and Secret access key values.
 
-1. Select `Services` link (on the top left of the page) and them type `IAM` in the search line
-1. Select the `IAM Manage User Access and Encryption Keys` item
-1. Select `Users` item from the menu on the left
-1. Press `Add user`
-1. Choose a user name, for example `user-calling-sns`
-1. Check `Programmatic access` but not anything else
-1. Press `Next: Permissions` button
-1. Press `Attach existing policies directly` icon
-1. Check `allow-sns` from the list of policies
-1. Press `Next: Review`
-1. Press `Create user`
-1. Copy down your `Access key ID` and `Secret access key`
+## Configure The API Keys For SNS ##
 
-## Configure the API keys for SNS
+At the top of the `sample.agent.nut` file there are three constants that need to be configured:
 
-At the top of the sample.agent.nut there are three constants that need to be configured.
-
-Parameter                   | Description
---------------------------- | -----------
-AWS_TEST_REGION             | AWS region (e.g. "us-west-2")
-AWS_SNS_ACCESS_KEY_ID       | IAM Access Key ID
-AWS_SNS_SECRET_ACCESS_KEY   | IAM Secret Access Key
-AWS_SNS_TOPIC_ARN           | Your SNS TOPIC ARN
-
-
-The AWSSNS library is licensed under the [MIT License](../LICENSE).
+Constant                      | Description
+----------------------------- | -----------
+*AWS_TEST_REGION*             | An AWS region (eg. `"us-west-2"`)
+*AWS_SNS_ACCESS_KEY_ID*       | Your IAM Access Key ID
+*AWS_SNS_SECRET_ACCESS_KEY*   | Your IAM Secret Access Key
+*AWS_SNS_TOPIC_ARN*           | Your SNS TOPIC ARN

--- a/example/sample.agent.nut
+++ b/example/sample.agent.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -23,7 +23,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #require "AWSRequestV4.class.nut:1.0.2"
-#require "AWSSNS.agent.lib.nut:1.0.0"
+#require "AWSSNS.agent.lib.nut:2.0.0"
 
 
 // Configure these parameters see example/README.md for details
@@ -63,12 +63,12 @@ http.onrequest(function(request, response) {
             }
 
             // Confirm the subscription
-            sns.action(AWSSNS_ACTION_CONFIRM_SUBSCRIPTION, confirmParams, function(res) {
+            sns.action(AWSSNS_ACTIONS.CONFIRM_SUBSCRIPTION, confirmParams, function(res) {
                 server.log("Confirmation Response: " + res.statuscode);
 
                 if (res.statuscode == 200) {
                     // Now that the subscription is established publish a message
-                    sns.action(AWSSNS_ACTION_PUBLISH, publishParams, function(res) {
+                    sns.action(AWSSNS_ACTIONS.PUBLISH, publishParams, function(res) {
                         server.log(" Publish Confirmation XML Response: " + res.body);
                     });
                 }
@@ -84,6 +84,6 @@ http.onrequest(function(request, response) {
 });
 
 // Subscribe to a topic
-sns.action(AWSSNS_ACTION_SUBSCRIBE, subscribeParams, function(res) {
+sns.action(AWSSNS_ACTIONS.SUBSCRIBE, subscribeParams, function(res) {
     server.log("Subscribe Response: " + res.statuscode);
 });

--- a/example/sample.agent.nut
+++ b/example/sample.agent.nut
@@ -27,7 +27,7 @@
 
 
 // Configure these parameters see example/README.md for details
-const AWS_SNS_TEST_REGION = "YOUR_REGION_HERE"
+const AWS_SNS_TEST_REGION = "YOUR_REGION_HERE";
 const AWS_SNS_ACCESS_KEY_ID = "YOUR_AWS_ACCESS_KEY_HERE";
 const AWS_SNS_SECRET_ACCESS_KEY = "YOUR_AWS_SECRET_ACCESS_KEY_HERE";
 const AWS_SNS_TOPIC_ARN = "YOUR_TOPIC_ARN_HERE";
@@ -49,13 +49,12 @@ publishParams <- {
 
 // Handle incoming HTTP requests which are sent in response to subscription to confirm said subscription
 http.onrequest(function(request, response) {
-
     try {
         local requestBody = http.jsondecode(request.body);
 
-        // Handle an SES SubscriptionConfirmation request
-        if ("Type" in requestBody && requestBody.Type == "SubscriptionConfirmation") {
-            server.log("Received HTTP Request: AWS_SNS SubscriptionConfirmation");
+        // Handle an SNS SubscriptionConfirmation request
+        if ("Type" in requestBody && requestBody.Type == AWSSNS_RESPONSES.SUBSCRIPTION_CONFIRMATION) {
+            server.log("Received HTTP Request: AWS SNS SubscriptionConfirmation");
 
             local confirmParams = {
                 "Token": requestBody.Token,
@@ -80,7 +79,6 @@ http.onrequest(function(request, response) {
         server.log("Error handling HTTP request: " + exception);
         response.send(500, "Internal Server Error: " + exception);
     }
-
 });
 
 // Subscribe to a topic

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,67 +1,63 @@
-# Test Instructions
+# Test Instructions #
 
 The instructions will show you how to set up the tests for AWS SNS.
 
 As the sample code includes the private key verbatim in the source, it should be treated carefully, and not checked into version control!
 
+## Set Up A Topic In AWS SNS ##
 
-## Setting up a Topic in AWS SNS
+1. Login to the [AWS console](https://aws.amazon.com/console/).
+1. Select **Services link** (on the top left of the page) and then type `SNS` in the search line.
+1. Select **Simple Notification Service**.
+1. Click **Create Topic**.
+1. Enter `testSNS` under **Topic name**.
+1. Enter `testSNS` under **DisplayName**.
+1. Click **Create Topic*.
+1. Note your Topic ARN and your Region.
 
-1. Login to the [AWS console](https://aws.amazon.com/console/)
-1. Select `Services link` (on the top left of the page) and then type `SNS` in the search line
-1. Select `Simple Notification Service`
-1. Click `Create Topic`
-1. Enter in `Topic name` "testSNS"
-1. Enter in `DisplayName` "testSNS"
-1. Click `Create Topic`
-1. Note your Topic ARN and your Region
+## Set Up An IAM Policy ##
 
-## Setting up IAM Policy
+1. Select the **Services** link (on the top left of the page) and them type `IAM` in the search line.
+1. Select the **IAM Manage User Access and Encryption Keys** item.
+1. Select the **Policies** item from the menu on the left.
+1. Click **Create Policy**.
+1. Click **Select** under **Policy Generator**.
+1. On the **Edit Permissions** page do the following:
+    1. Set **Effect** to **Allow**.
+    1. Set **AWS Service** to **Amazon SNS**.
+    1. Set **Actions** to **All Actions**.
+    1. Set **Amazon Resource Name (ARN)** to **&#42;**.
+    1. Click **Add Statement**.
+    1. Click **Next Step**.
+1. Give your policy a name, for example, `allow-sns` and type in into the **Policy Name** field.
+1. Click **Create Policy**.
 
-1. Select `Services` link (on the top left of the page) and them type `IAM` in the search line
-1. Select `IAM Manage User Access and Encryption Keys` item
-1. Select `Policies` item from the menu on the left
-1. Press `Create Policy` button
-1. Press `Select` for `Policy Generator`
-1. On the `Edit Permissions` page do the following
-    1. Set `Effect` to `Allow`
-    1. Set `AWS Service` to `Amazon SNS`
-    1. Set `Actions` to `All Actions`
-    1. Set `Amazon Resource Name (ARN)` to `*`
-    1. Press `Add Statement`
-    1. Press `Next Step`
-1. Give your policy a name, for example, `allow-sns` and type in into the `Policy Name` field
-1. Press `Create Policy`
+## Set Up An IAM User ##
 
-## Setting up the IAM User
+1. Select the **Services** link (on the top left of the page) and them type `IAM` in the search line.
+1. Select the **IAM Manage User Access and Encryption Keys** item.
+1. Select the **Users** item from the menu on the left.
+1. Click **Add user**.
+1. Choose a user name, for example `user-calling-sns`.
+1. Check **Programmatic access** but not anything else.
+1. Click **Next: Permissions**
+1. Click the **Attach existing policies directly** icon.
+1. Check **allow-sns** from the list of policies.
+1. Click **Next: Review**.
+1. Click **Create user**.
+1. Note your Access key ID and Secret access key values.
 
-1. Select `Services` link (on the top left of the page) and them type `IAM` in the search line
-1. Select the `IAM Manage User Access and Encryption Keys` item
-1. Select `Users` item from the menu on the left
-1. Press `Add user`
-1. Choose a user name, for example `user-calling-sns`
-1. Check `Programmatic access` but not anything else
-1. Press `Next: Permissions` button
-1. Press `Attach existing policies directly` icon
-1. Check `allow-sns` from the list of policies
-1. Press `Next: Review`
-1. Press `Create user`
-1. Copy down your `Access key ID` and `Secret access key`
+## Configure The API Keys For SNS ##
 
-## Configure the API keys for SNS
+At the top of the `agent.test.nut` file there are four constants that need to be configured:
 
-At the top of the agent.test.nut there are four constants that need to be configured.
+Constant                      | Description
+----------------------------- | -----------
+*AWS_TEST_REGION*             | An AWS region (eg. `"us-west-2"`)
+*AWS_SNS_ACCESS_KEY_ID*       | Your IAM Access Key ID
+*AWS_SNS_SECRET_ACCESS_KEY*   | Your IAM Secret Access Key
+*AWS_SNS_TOPIC_ARN*           | Your SNS TOPIC ARN
 
-Parameter                   | Description
---------------------------- | -----------
-AWS_TEST_REGION             | AWS region (e.g. "us-west-2")
-AWS_SNS_ACCESS_KEY_ID       | IAM Access Key ID
-AWS_SNS_SECRET_ACCESS_KEY   | IAM Secret Access Key
-AWS_SNS_TOPIC_ARN           | Your SNS TOPIC ARN
+## Imptest ##
 
-## Imptest
- Please ensure that the `.imptest` agent file includes both AWSRequestV4 library and the AWSSNS class.
-
-# License
-
-The AWSSQS library is licensed under the [MIT License](../LICENSE).
+Please ensure that the `.imptest` agent file includes both the AWSRequestV4 library and the AWSSNS library.

--- a/tests/agent.test.nut
+++ b/tests/agent.test.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -92,7 +92,7 @@ class AgentTestCase extends ImpTestCase {
                             "Token": requestBody.Token,
                             "TopicArn": requestBody.TopicArn
                         };
-                        _sns.action(AWSSNS_ACTION_CONFIRM_SUBSCRIPTION, confirmParams, function(res) {
+                        _sns.action(AWSSNS_ACTIONS.CONFIRM_SUBSCRIPTION, confirmParams, function(res) {
 
                             try {
                                 if (firstInstanceConfirmation == true) {
@@ -112,7 +112,7 @@ class AgentTestCase extends ImpTestCase {
             }.bindenv(this));
 
             // Fresh subscribe to ensure timely http message sent to the agent
-            _sns.action(AWSSNS_ACTION_SUBSCRIBE, subscribeParams, function(res) {});
+            _sns.action(AWSSNS_ACTIONS.SUBSCRIBE, subscribeParams, function(res) {});
         }.bindenv(this));
     }
 
@@ -137,7 +137,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_SUBSCRIBE, subscribeParams, function(res) {
+            _sns.action(AWSSNS_ACTIONS.SUBSCRIBE, subscribeParams, function(res) {
 
                 try {
                     this.assertTrue(subscriptionFinder(res.body) == "pending confirmation", "actual status " + subscriptionFinder(res.body));
@@ -189,7 +189,7 @@ class AgentTestCase extends ImpTestCase {
                             "Token": requestBody.Token,
                             "TopicArn": requestBody.TopicArn
                         };
-                        _sns.action(AWSSNS_ACTION_CONFIRM_SUBSCRIPTION, confirmParams, function(res) {
+                        _sns.action(AWSSNS_ACTIONS.CONFIRM_SUBSCRIPTION, confirmParams, function(res) {
 
                             try {
                                 if (firstInstanceConfirmation == true) {
@@ -211,7 +211,7 @@ class AgentTestCase extends ImpTestCase {
             }.bindenv(this));
 
             // Fresh subscribe to ensure timely http message sent to the agent
-            _sns.action(AWSSNS_ACTION_SUBSCRIBE, subscribeParams, function(res) {});
+            _sns.action(AWSSNS_ACTIONS.SUBSCRIBE, subscribeParams, function(res) {});
         }.bindenv(this));
     }
 
@@ -244,12 +244,12 @@ class AgentTestCase extends ImpTestCase {
         return Promise(function(resolve, reject) {
 
             imp.wakeup(5, function() {
-                _sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS, {}, function(res) {
+                _sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS, {}, function(res) {
 
                     if (endpointFinder(res.body, _endpoint) == null) {
                         imp.wakeup(5, function() {
 
-                            _sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS, {}, function(res) {
+                            _sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS, {}, function(res) {
 
                                 try {
                                     this.assertTrue(res.statuscode == AWS_TEST_HTTP_RESPONSE_SUCCESS, "Actual response " + res.statuscode);
@@ -317,7 +317,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS_BY_TOPIC, params, function(res) {
 
                 try {
                     this.assertTrue(_subscriptionArn == subscriptionFinder(res.body, endpointFinder(res.body, _endpoint)), "Actual Arn " + subscriptionFinder(res.body, endpointFinder(res.body, _endpoint)));
@@ -338,7 +338,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_LIST_TOPICS, {}, function(res) {
+            _sns.action(AWSSNS_ACTIONS.LIST_TOPICS, {}, function(res) {
 
                 try {
                     this.assertTrue(res.body.find(AWS_SNS_TOPIC_ARN) != null, "TopicArn not found");
@@ -363,7 +363,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_PUBLISH, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.PUBLISH, params, function(res) {
 
                 try {
                     // Checks the received status code
@@ -389,12 +389,12 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_UNSUBSCRIBE, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.UNSUBSCRIBE, params, function(res) {
 
                 try {
                     this.assertTrue(res.statuscode == AWS_TEST_HTTP_RESPONSE_SUCCESS, "Actual response " + res.statuscode);
 
-                    _sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS, {}, function(res) {
+                    _sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS, {}, function(res) {
 
                         this.assertTrue(res.body.find(_subscriptionArn) == null, "Actual index " + res.body.find(_subscriptionArn));
                         resolve();
@@ -417,7 +417,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_UNSUBSCRIBE, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.UNSUBSCRIBE, params, function(res) {
 
                 try {
                     this.assertTrue(res.statuscode == AWS_TEST_HTTP_RESPONSE_BAD_REQUEST, "Actual response " + res.statuscode);
@@ -440,7 +440,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_LIST_SUBSCRIPTIONS_BY_TOPIC, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.LIST_SUBSCRIPTIONS_BY_TOPIC, params, function(res) {
 
                 try {
                     this.assertTrue(res.statuscode == AWS_TEST_HTTP_RESPONSE_BAD_REQUEST, "Actual response " + res.statuscode);
@@ -459,7 +459,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_LIST_TOPICS, {}, function(res) {
+            _sns.action(AWSSNS_ACTIONS.LIST_TOPICS, {}, function(res) {
 
                 try {
                     this.assertTrue(res.body.find(AWS_SNS_TOPIC_ARN) != null, "TopicArn not found");
@@ -484,7 +484,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_PUBLISH, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.PUBLISH, params, function(res) {
 
                 try {
                     // Checks the received status code
@@ -510,7 +510,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_PUBLISH, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.PUBLISH, params, function(res) {
 
                 try {
                     // Checks the received status code
@@ -534,7 +534,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_SUBSCRIBE, subscribeParams, function(res) {
+            _sns.action(AWSSNS_ACTIONS.SUBSCRIBE, subscribeParams, function(res) {
 
                 try {
                     this.assertTrue(res.statuscode == AWS_TEST_HTTP_RESPONSE_BAD_REQUEST, "Actual response " + res.statuscode);
@@ -557,7 +557,7 @@ class AgentTestCase extends ImpTestCase {
 
         return Promise(function(resolve, reject) {
 
-            _sns.action(AWSSNS_ACTION_UNSUBSCRIBE, params, function(res) {
+            _sns.action(AWSSNS_ACTIONS.UNSUBSCRIBE, params, function(res) {
                 resolve();
             }.bindenv(this));
 


### PR DESCRIPTION
See https://electricimp.atlassian.net/browse/CSE-790

I've updated the library with new-style comments, and I've taken the opportunity to recast the constants as enums (though this can be easily changed back, if you prefer).

The example and tests have likewise been modernised, so this is all worth a '-docs' update if you don't want to bump the library version because of the const/enum change.

I've updated the examples in the Read Me so they don't reference undeclared consts (which were actually from the test file).